### PR TITLE
Update version scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "scss:prettify": "prettier --write 'scss/**/*.scss'",
     "scss:prepublish": "cd scss/ && zip -r ../dist/undernet.scss.zip .",
     "update-version": "node scripts/update-version.js",
-    "create-hashes": "node scripts/create-hashes.js"
+    "create-hashes": "node scripts/create-hashes.js",
+    "preversion": "npm test",
+    "postversion": "npm run update-version && npm test -- -u && npm run build:dist:release && git add -A"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -2,67 +2,46 @@
 
 const fs = require("fs")
 const path = require("path")
-const args = require("yargs").argv
 
 // set up for operations
 
-const newUndernetVersion = args.tag
-
 const packageFilePath = path.resolve(__dirname, "../package.json")
 const pkg = require(packageFilePath)
-const currentUndernetVersion = pkg.version
+const nextVersion = pkg.version
 
 const undernetScssFilePath = path.resolve(__dirname, "../scss/undernet.scss")
 const downloadArticleFilePath = path.resolve(__dirname, "../site/docs/download.md")
 const readFormat = "utf-8"
-
-// get update for package.json
-
-function getPackageVersion(version) {
-  return `"version": "${version}"`
-}
-
-function getNewPackageVersion() {
-  const packageVersion = getPackageVersion(currentUndernetVersion)
-  const newPackageVersion = getPackageVersion(newUndernetVersion)
-  const packageFile = fs.readFileSync(packageFilePath, readFormat)
-  return packageFile.replace(packageVersion, newPackageVersion)
-}
+let currentVersion
 
 // get update for scss/undernet.scss
 
-function getScssVersion(version) {
-  return `v${version}`
-}
+const getScssVersion = version => `v${version}`
 
-function getNewScssVersion() {
-  const scssVersion = getScssVersion(currentUndernetVersion)
-  const newScssVersion = getScssVersion(newUndernetVersion)
+function setNewScssVersion() {
   const undernetScssFile = fs.readFileSync(undernetScssFilePath, readFormat)
-  return undernetScssFile.replace(scssVersion, newScssVersion)
+  currentVersion = undernetScssFile.match(/v\S+/g)[1]
+  const currentVersionString = getScssVersion(currentVersion)
+  const newVersionString = getScssVersion(nextVersion)
+  return undernetScssFile.replace(currentVersionString, newVersionString)
 }
 
 // get update for site/docs/download.md
 
-function getArticleVersion(version) {
-  return `@${version}`
-}
+const getArticleVersion = version => `@${version}`
 
-function getNewIntroductionArticle() {
-  const articleVersion = getArticleVersion(currentUndernetVersion)
-  const newArticleVersion = getArticleVersion(newUndernetVersion)
+function setNewIntroArticleVersion() {
   const downloadArticleFile = fs.readFileSync(downloadArticleFilePath, readFormat)
+  const articleVersion = getArticleVersion(currentVersion)
   const versionRegEx = new RegExp(articleVersion, "g")
-  return downloadArticleFile.replace(versionRegEx, newArticleVersion)
+  const newVersionString = getArticleVersion(nextVersion)
+  return downloadArticleFile.replace(versionRegEx, newVersionString)
 }
 
 // write to files
 
-fs.writeFileSync(packageFilePath, getNewPackageVersion(), readFormat)
-console.log(`-> package.json version updated to ${newUndernetVersion}!`)
+fs.writeFileSync(undernetScssFilePath, setNewScssVersion(), readFormat)
+console.log(`-> scss/undernet.scss version updated to ${nextVersion}!`)
 
-fs.writeFileSync(undernetScssFilePath, getNewScssVersion(), readFormat)
-console.log(`-> scss/undernet.scss version updated to ${newUndernetVersion}!`)
-
-fs.writeFileSync(downloadArticleFilePath, getNewIntroductionArticle(), readFormat)
-console.log(`-> site/docs/download.md version updated to ${newUndernetVersion}!`)
+fs.writeFileSync(downloadArticleFilePath, setNewIntroArticleVersion(), readFormat)
+console.log(`-> site/docs/download.md version updated to ${nextVersion}!`)


### PR DESCRIPTION
Removes manual version increments with update-version script. Now uses npm preversion and postversion.