### PR TITLE
Fix modal dialog, tooltip, and dropdown menu elements breaking viewport when text zoom is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ This will do a few things:
 1. Run the full test suite to ensure the library is stable.
 2. Increment the package by the version you specify, and tag it appropriately
 3. Run a custom node script to update appropriate files with the new version
-4. Rerun the test suite to update snapshots for the build, then build all package assets
+4. Build all package assets for publishing
 5. Create new content hashes to be used with cdn subresource integrity links in the docs
 6. Add all new build assets to the version commit and open a prompt for the release's commit message
 
 The release commit is usually in this format: `[Version X.X.X] This release does x, y, and z.`
 
-The commit will be ready to merge to master. After that, the repo can be published to npm.
+The commit will be ready to merge to master. After that, the repo can be published to npm. I recommend using `npm publish --dry-run` to confirm the output is what you expect. Then remove the flag and a new version is out in the world!

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -666,6 +666,7 @@ $modal-container-border-radius: $global-border-radius !default;
 $modal-container-padding: $global-space !default;
 $modal-container-width: em(450px) !default;
 $modal-container-width-small: 95% !default;
+$modal-container-max-width: 95vw !default;
 $modal-container-margin: 40px auto !default;
 $modal-container-margin-small: $global-space auto !default;
 
@@ -717,6 +718,7 @@ $dropdown-menu-padding: 8px 0 !default;
 $dropdown-menu-border-radius: $global-border-radius !default;
 $dropdown-menu-background-color: $white !default;
 $dropdown-menu-width: em(200px) !default;
+$dropdown-menu-max-width: 95vw !default;
 $dropdown-menu-border: 1px solid $dropdown-border-color !default;
 
 $dropdown-arrow-offset: 12px !default;

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -36,6 +36,7 @@
     border-radius: $dropdown-menu-border-radius;
     background: $dropdown-menu-background-color;
     width: $dropdown-menu-width;
+    max-width: $dropdown-menu-max-width;
     border: $dropdown-menu-border;
     z-index: $dropdown-menu-index;
 

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -30,6 +30,7 @@
   .modal-dialog {
     background: $modal-container-background-color;
     width: $modal-container-width-small;
+    max-width: $modal-container-max-width;
     position: relative;
     flex-flow: column nowrap;
     display: flex;


### PR DESCRIPTION
Dialog and dropdown menu's use a static `width` property, with no `max-width`. this causes them to break out of the viewport using text zoom.

Similarly, tooltips are absolutely positioned, so they need to be reigned in using `max-width` as well.