### PR TITLE
Collapsible accessibility fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,7 +146,7 @@ module.exports = {
     "require-await": ERROR,
     "require-unicode-regexp": OFF,
     "vars-on-top": ERROR,
-    "wrap-iife": ERROR,
+    "wrap-iife": "outside",
     yoda: [ERROR, "never", { exceptRange: true }],
 
     // variables

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,7 +146,7 @@ module.exports = {
     "require-await": ERROR,
     "require-unicode-regexp": OFF,
     "vars-on-top": ERROR,
-    "wrap-iife": "outside",
+    "wrap-iife": [ERROR, "outside"],
     yoda: [ERROR, "never", { exceptRange: true }],
 
     // variables

--- a/site/_includes/partials/page-footer.html
+++ b/site/_includes/partials/page-footer.html
@@ -21,7 +21,7 @@
           </a>
         </li>
         <li class="has-no-p">
-          <button class="is-visually-hidden-focusable" onclick={handleClick} type="button">
+          <button id="footer-jump-button" class="is-visually-hidden-focusable">
             Return to top of page
           </button>
         </li>

--- a/site/_includes/partials/page-header.html
+++ b/site/_includes/partials/page-header.html
@@ -9,7 +9,7 @@
       <li class="is-sm-7 is-xs-12 column">
         <ul class="row">
           <li>
-            <button class="is-visually-hidden-focusable" type="button">
+            <button id="header-jump-button" class="is-visually-hidden-focusable" type="button">
               Skip to main content
             </button>
           </li>

--- a/site/_scripts/_jump-nav.js
+++ b/site/_scripts/_jump-nav.js
@@ -1,0 +1,15 @@
+import { focusOnce } from "undernet/helpers/utils"
+
+const headerJumpBtn = document.getElementById("header-jump-button")
+const footerJumpBtn = document.getElementById("footer-jump-button")
+
+const handleHeaderJump = () => {
+  focusOnce(document.querySelector("main"))
+}
+
+const handleFooterJump = () => {
+  focusOnce(document.querySelector("header"))
+}
+
+headerJumpBtn.addEventListener("click", handleHeaderJump)
+footerJumpBtn.addEventListener("click", handleFooterJump)

--- a/site/_scripts/docs.js
+++ b/site/_scripts/docs.js
@@ -1,5 +1,6 @@
 import Undernet from "undernet"
 import { throttle } from "lodash-es"
+import "./_jump-nav"
 
 const DISPLAY_NONE_CLASS = "is-d-none"
 const ARIA_EXPANDED_ATTR = "aria-expanded"

--- a/site/_scripts/home.js
+++ b/site/_scripts/home.js
@@ -1,4 +1,5 @@
 import { createFocusRing } from "undernet"
+import "./_jump-nav"
 
 document.addEventListener("DOMContentLoaded", () => {
   createFocusRing().start()

--- a/site/docs/collapsibles.md
+++ b/site/docs/collapsibles.md
@@ -15,12 +15,12 @@ Check out this example collapsible:
 <div class="collapsible" data-collapsible="collapsible-1">
   <h5>
     <button class="collapsible-trigger" id="trigger-1" data-target="collapsible-1">
-      Press to collapse
+      Press to expand
     </button>
   </h5>
   <div class="collapsible-content" id="collapsible-1">
     <p class="has-p">
-      It's just lorem ipsum. Consectetur eiusmod laboris in non id tempor exercitation ipsum cupidatat magna ipsum ut voluptate. <a>A link,</a> and <a>another link!</a>
+      It's just lorem ipsum. Consectetur eiusmod laboris in non id tempor exercitation ipsum cupidatat magna ipsum ut voluptate. <a href="#">A link,</a> and <a href="#">another link!</a>
     </p>
   </div>
 </div>
@@ -43,9 +43,9 @@ Check out this example collapsible:
 
 ## Controlling Visibility
 
-Any given collapsible's content will be expanded by default. To force the content to be hidden at page load, add `data-visible="false"` on the wrapper.
+Any given collapsible's content will be hidden by default. To force the content to be visible at page load, add `data-visible="true"` on the wrapper.
 
-<div class="collapsible" data-visible="false" data-collapsible="collapsible-2">
+<div class="collapsible" data-visible="true" data-collapsible="collapsible-2">
   <h5>
     <button class="collapsible-trigger" id="trigger-2" data-target="collapsible-2">
       Open for cake
@@ -53,7 +53,8 @@ Any given collapsible's content will be expanded by default. To force the conten
   </h5>
   <div class="collapsible-content" id="collapsible-2">
     <p class="has-p">
-      Sorry, just gibberish. Consectetur eiusmod laboris in non id tempor exercitation ipsum cupidatat magna ipsum ut voluptate. <a>A link,</a> and <a>another link!</a>
+      Sorry, just gibberish. Consectetur eiusmod laboris in non id tempor exercitation ipsum
+      cupidatat magna ipsum ut voluptate. <a>A link,</a> and <a>another link!</a>
     </p>
   </div>
 </div>

--- a/site/docs/dropdowns.md
+++ b/site/docs/dropdowns.md
@@ -15,9 +15,9 @@ Check out this example dropdown:
 <div data-dropdown="dropdown1" class="dropdown">
   <button id="dropdown-button-id" data-parent="dropdown1" data-target="dropdown-menu-id">Open Dropdown</button>
   <ul id="dropdown-menu-id" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -69,9 +69,9 @@ Alternatively, you can force the arrow to hide using the `has-no-arrow` class on
 <div data-dropdown="dropdown20" class="dropdown">
   <button id="dropdown-button-id20" data-parent="dropdown20" data-target="dropdown-menu-id20">Open Dropdown</button>
   <ul id="dropdown-menu-id20" class="dropdown-menu has-no-arrow">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -95,23 +95,23 @@ You can use any button style with a dropdown. Just add the appropriate class to 
 <div data-dropdown="dropdown2" class="dropdown">
   <button class="is-primary" id="dropdown-button-id2" data-parent="dropdown2" data-target="dropdown-menu-id2">Primary Button</button>
   <ul id="dropdown-menu-id2" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div> <div data-dropdown="dropdown3" class="dropdown">
   <button class="is-secondary" id="dropdown-button-id3" data-parent="dropdown3" data-target="dropdown-menu-id3">Secondary Button</button>
   <ul id="dropdown-menu-id3" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div> <div data-dropdown="dropdown4" class="dropdown">
   <button class="is-tertiary" id="dropdown-button-id4" data-parent="dropdown4" data-target="dropdown-menu-id4">Tertiary Button</button>
   <ul id="dropdown-menu-id4" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -125,8 +125,8 @@ You can let it align inline-end using `is-aligned-inline-end`, or from block-end
   <button id="dropdown-button-id5" data-parent="dropdown5" data-target="dropdown-menu-id5">Open Dropdown</button>
   <ul id="dropdown-menu-id5" class="dropdown-menu is-aligned-inline-end">
     <li><h6 class="dropdown-header">Aligned Block-End</h6></li>
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
   </ul>
 </div>
 
@@ -152,20 +152,20 @@ You can let it drop block-start, inline-start, and inline-end using `is-drop-blo
 <div data-dropdown="dropdown9" class="dropdown">
   <button id="dropdown-button-id9" data-parent="dropdown9" data-target="dropdown-menu-id9">Drop Block-Start</button>
   <ul id="dropdown-menu-id9" class="dropdown-menu is-drop-block-start">
-    <li><a>Item 1</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div> <div data-dropdown="dropdown-id11" class="dropdown">
   <button id="dropdown-button-id11" data-parent="dropdown-id11" data-target="dropdown-menu-id30">Drop Inline-End</button>
   <ul id="dropdown-menu-id30" class="dropdown-menu is-drop-inline-end">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
   </ul>
 </div> <div data-dropdown="dropdown10" class="dropdown">
   <button id="dropdown-button-id10" data-parent="dropdown10" data-target="dropdown-menu-id10">Drop Inline-Start</button>
   <ul id="dropdown-menu-id10" class="dropdown-menu is-drop-inline-start">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
   </ul>
 </div>
 
@@ -204,23 +204,23 @@ You can also combine direction with alignment to get even more customization!
 <div data-dropdown="dropdown21" class="dropdown">
   <button id="dropdown-button-id21" data-parent="dropdown21" data-target="dropdown-menu-id21">Drop Block-Start, Aligned Inline-End</button>
   <ul id="dropdown-menu-id21" class="dropdown-menu is-drop-block-start is-aligned-inline-end">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div> <div data-dropdown="dropdown23" class="dropdown">
   <button id="dropdown-button-id23" data-parent="dropdown23" data-target="dropdown-menu-id23">Drop Inline-End, Aligned Block-End</button>
   <ul id="dropdown-menu-id23" class="dropdown-menu is-drop-inline-end is-aligned-block-end">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div> <div data-dropdown="dropdown22" class="dropdown">
   <button id="dropdown-button-id22" data-parent="dropdown22" data-target="dropdown-menu-id22">Drop Inline-Start, Aligned Block-End</button>
   <ul id="dropdown-menu-id22" class="dropdown-menu is-drop-inline-start is-aligned-block-end">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -261,9 +261,9 @@ Add an `<hr/>` to a dropdown list item to create a visual separator between butt
 <div data-dropdown="dropdown6" class="dropdown">
   <button id="dropdown-button-id6" data-parent="dropdown6" data-target="dropdown-menu-id6">Open Dropdown</button>
   <ul id="dropdown-menu-id6" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a><hr /></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a><hr /></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -295,10 +295,10 @@ You can add any level of header to a dropdown menu.
   <button id="dropdown-button-id7" data-parent="dropdown7" data-target="dropdown-menu-id7">Open Dropdown</button>
   <ul id="dropdown-menu-id7" class="dropdown-menu">
     <li><h3 class="dropdown-header">Menu Header (h3)</h3></li>
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
     <li><h5 class="dropdown-header">Menu Header (h5)</h5></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 
@@ -327,8 +327,8 @@ Paragraph text will wrap like it does everywhere else. Use spacing utilities to 
     <li class="has-p-sm has-gray800-text-color">
       Would you like to receive newsletters from Cool Company, Inc?
     </li>
-    <li><a>Sure!</a></li>
-    <li><a>Nope</a></li>
+    <li><a href="#0">Sure!</a></li>
+    <li><a href="#0">Nope</a></li>
   </ul>
 </div>
 
@@ -390,9 +390,9 @@ The menu itself only needs one attribute.
 <div data-dropdown="dropdown1" class="dropdown">
   ...
   <ul id="dropdown-menu-id" class="dropdown-menu">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-    <li><a>Item 3</a></li>
+    <li><a href="#0">Item 1</a></li>
+    <li><a href="#0">Item 2</a></li>
+    <li><a href="#0">Item 3</a></li>
   </ul>
 </div>
 ```

--- a/src/js/collapsible/__tests__/__snapshots__/collapsible.spec.js.snap
+++ b/src/js/collapsible/__tests__/__snapshots__/collapsible.spec.js.snap
@@ -1,6 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
+exports[`Collapsible #handleClick toggles collapsible closed on click 1`] = `
+<body>
+  
+  
+  <div
+    class="collapsible"
+    data-collapsible="collapsible-id"
+    data-visible="false"
+  >
+    
+    
+    <h5>
+      
+      
+      <button
+        aria-controls="collapsible-id"
+        aria-expanded="false"
+        class="collapsible-trigger"
+        data-target="collapsible-id"
+        id="collapsible-trigger-id"
+      >
+        
+        Collapsible Trigger
+      
+      </button>
+      
+    
+    </h5>
+    
+    
+    <div
+      aria-hidden="true"
+      aria-labelledby="collapsible-trigger-id"
+      class="collapsible-content"
+      id="collapsible-id"
+    >
+      
+      
+      <p
+        class="has-p"
+      >
+        
+        Consectetur eiusmod laboris in non id tempor exercitation ipsum cupidatat magna
+        ipsum ut voluptate. 
+        <a
+          href="#"
+        >
+          E pluribus unum.
+        </a>
+        
+      
+      </p>
+      
+    
+    </div>
+    
+  
+  </div>
+  
+
+</body>
+`;
+
+exports[`Collapsible #handleClick toggles collapsible open on click 1`] = `
 <body>
   
   

--- a/src/js/collapsible/__tests__/__snapshots__/collapsible.spec.js.snap
+++ b/src/js/collapsible/__tests__/__snapshots__/collapsible.spec.js.snap
@@ -7,7 +7,7 @@ exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
   <div
     class="collapsible"
     data-collapsible="collapsible-id"
-    data-visible="false"
+    data-visible="true"
   >
     
     
@@ -16,7 +16,7 @@ exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
       
       <button
         aria-controls="collapsible-id"
-        aria-expanded="false"
+        aria-expanded="true"
         class="collapsible-trigger"
         data-target="collapsible-id"
         id="collapsible-trigger-id"
@@ -31,11 +31,11 @@ exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
     
     
     <div
-      aria-hidden="true"
+      aria-hidden="false"
       aria-labelledby="collapsible-trigger-id"
       class="collapsible-content"
       id="collapsible-id"
-      style=""
+      style="height: 0px; visibility: visible;"
     >
       
       
@@ -47,7 +47,6 @@ exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
         ipsum ut voluptate. 
         <a
           href="#"
-          tabindex="-1"
         >
           E pluribus unum.
         </a>
@@ -65,14 +64,14 @@ exports[`Collapsible #handleClick toggles collapsible on click 1`] = `
 </body>
 `;
 
-exports[`Collapsible API start does not open collapsible by default if [data-visible='false'] is set 1`] = `
+exports[`Collapsible API start opens collapsible by default if [data-visible='true'] is set 1`] = `
 <body>
   
   
   <div
     class="collapsible"
     data-collapsible="collapsible-id"
-    data-visible="false"
+    data-visible="true"
   >
     
     
@@ -81,7 +80,7 @@ exports[`Collapsible API start does not open collapsible by default if [data-vis
       
       <button
         aria-controls="collapsible-id"
-        aria-expanded="false"
+        aria-expanded="true"
         class="collapsible-trigger"
         data-target="collapsible-id"
         id="collapsible-trigger-id"
@@ -96,10 +95,11 @@ exports[`Collapsible API start does not open collapsible by default if [data-vis
     
     
     <div
-      aria-hidden="true"
+      aria-hidden="false"
       aria-labelledby="collapsible-trigger-id"
       class="collapsible-content"
       id="collapsible-id"
+      style="height: 0px; visibility: visible;"
     >
       
       
@@ -111,7 +111,6 @@ exports[`Collapsible API start does not open collapsible by default if [data-vis
         ipsum ut voluptate. 
         <a
           href="#"
-          tabindex="-1"
         >
           E pluribus unum.
         </a>
@@ -136,7 +135,7 @@ exports[`Collapsible API start sets attributes 1`] = `
   <div
     class="collapsible"
     data-collapsible="collapsible-id"
-    data-visible="true"
+    data-visible="false"
   >
     
     
@@ -145,7 +144,7 @@ exports[`Collapsible API start sets attributes 1`] = `
       
       <button
         aria-controls="collapsible-id"
-        aria-expanded="true"
+        aria-expanded="false"
         class="collapsible-trigger"
         data-target="collapsible-id"
         id="collapsible-trigger-id"
@@ -160,11 +159,10 @@ exports[`Collapsible API start sets attributes 1`] = `
     
     
     <div
-      aria-hidden="false"
+      aria-hidden="true"
       aria-labelledby="collapsible-trigger-id"
       class="collapsible-content"
       id="collapsible-id"
-      style="max-height: 0rem;"
     >
       
       
@@ -176,7 +174,6 @@ exports[`Collapsible API start sets attributes 1`] = `
         ipsum ut voluptate. 
         <a
           href="#"
-          tabindex="0"
         >
           E pluribus unum.
         </a>
@@ -201,7 +198,7 @@ exports[`Collapsible API stop + #handleClick does not toggle collapsible on clic
   <div
     class="collapsible"
     data-collapsible="collapsible-id"
-    data-visible="true"
+    data-visible="false"
   >
     
     
@@ -210,7 +207,7 @@ exports[`Collapsible API stop + #handleClick does not toggle collapsible on clic
       
       <button
         aria-controls="collapsible-id"
-        aria-expanded="true"
+        aria-expanded="false"
         class="collapsible-trigger"
         data-target="collapsible-id"
         id="collapsible-trigger-id"
@@ -225,11 +222,10 @@ exports[`Collapsible API stop + #handleClick does not toggle collapsible on clic
     
     
     <div
-      aria-hidden="false"
+      aria-hidden="true"
       aria-labelledby="collapsible-trigger-id"
       class="collapsible-content"
       id="collapsible-id"
-      style="max-height: 0rem;"
     >
       
       
@@ -241,7 +237,6 @@ exports[`Collapsible API stop + #handleClick does not toggle collapsible on clic
         ipsum ut voluptate. 
         <a
           href="#"
-          tabindex="0"
         >
           E pluribus unum.
         </a>

--- a/src/js/collapsible/__tests__/collapsible.spec.js
+++ b/src/js/collapsible/__tests__/collapsible.spec.js
@@ -61,10 +61,20 @@ describe("Collapsible", () => {
   })
 
   describe("#handleClick", () => {
-    it("toggles collapsible on click", () => {
+    it("toggles collapsible open on click", () => {
       const trigger = find("button")
       // When
       Undernet.Collapsibles.start()
+      trigger.click()
+      // Then
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it("toggles collapsible closed on click", () => {
+      const trigger = find("button")
+      // When
+      Undernet.Collapsibles.start()
+      trigger.click()
       trigger.click()
       // Then
       expect(wrapper).toMatchSnapshot()

--- a/src/js/collapsible/__tests__/collapsible.spec.js
+++ b/src/js/collapsible/__tests__/collapsible.spec.js
@@ -39,8 +39,8 @@ describe("Collapsible", () => {
       expect(wrapper).toMatchSnapshot()
     })
 
-    it("does not open collapsible by default if [data-visible='false'] is set", () => {
-      find("[data-collapsible]").setAttribute("data-visible", "false")
+    it("opens collapsible by default if [data-visible='true'] is set", () => {
+      find("[data-collapsible]").setAttribute("data-visible", "true")
       // When
       Undernet.Collapsibles.start()
       // Then

--- a/src/js/collapsible/collapsible.js
+++ b/src/js/collapsible/collapsible.js
@@ -59,6 +59,11 @@ export default class Collapsible {
       return false
     }
 
+    if (!trigger.id) {
+      log(Messages.NO_TRIGGER_ID_ERROR(id))
+      return false
+    }
+
     const contentId = `#${id}`
     const content = dom.find(contentId, instance)
 
@@ -67,25 +72,21 @@ export default class Collapsible {
       return false
     }
 
-    if (!trigger.id) {
-      log(Messages.NO_TRIGGER_ID_ERROR(id))
-      return false
-    }
-
     dom.setAttr(trigger, Selectors.ARIA_CONTROLS, id)
     dom.setAttr(content, Selectors.ARIA_LABELLEDBY, trigger.id)
 
-    const contentIsHidden = dom.getAttr(instance, Selectors.DATA_VISIBLE) === "false"
+    const contentIsVisible = dom.getAttr(instance, Selectors.DATA_VISIBLE) === "true"
 
-    if (contentIsHidden) {
-      dom.setAttr(trigger, Selectors.ARIA_EXPANDED, "false")
-      dom.setAttr(content, Selectors.ARIA_HIDDEN, "true")
-    } else {
+    if (contentIsVisible) {
       dom.setAttr(instance, Selectors.DATA_VISIBLE, "true")
-      dom.setStyle(content, CssProperties.HEIGHT, `${content.scrollHeight}px`)
-      dom.setStyle(content, CssProperties.VISIBILITY, CssValues.VISIBLE)
       dom.setAttr(trigger, Selectors.ARIA_EXPANDED, "true")
       dom.setAttr(content, Selectors.ARIA_HIDDEN, "false")
+      dom.setStyle(content, CssProperties.HEIGHT, `${content.scrollHeight}px`)
+      dom.setStyle(content, CssProperties.VISIBILITY, CssValues.VISIBLE)
+    } else {
+      dom.setAttr(instance, Selectors.DATA_VISIBLE, "false")
+      dom.setAttr(trigger, Selectors.ARIA_EXPANDED, "false")
+      dom.setAttr(content, Selectors.ARIA_HIDDEN, "true")
     }
 
     requestAnimationFrame(() => {
@@ -144,15 +145,11 @@ export default class Collapsible {
   }
 
   _expandPanel(height) {
-    const transitionValue = dom.getStyle(this._activeContent, CssProperties.TRANSITION)
-    dom.setStyle(this._activeContent, CssProperties.TRANSITION, "")
-
-    requestAnimationFrame(() => {
+    return requestAnimationFrame(() => {
       dom.setStyle(this._activeContent, CssProperties.HEIGHT, height)
-      dom.setStyle(this._activeContent, CssProperties.TRANSITION, transitionValue)
 
       requestAnimationFrame(() => {
-        dom.setStyle(this._activeContent, CssProperties.HEIGHT, CssValues.ZERO_PX)
+        dom.setStyle(this._activeContent, CssProperties.HEIGHT, null)
         dom.setStyle(this._activeContent, CssProperties.VISIBILITY, CssValues.HIDDEN)
       })
     })

--- a/src/js/collapsible/collapsible.js
+++ b/src/js/collapsible/collapsible.js
@@ -14,7 +14,7 @@ export default class Collapsible {
     // events
     this._handleClick = throttle(this._handleClick.bind(this), 300)
     this._handleTransitionEnd = this._handleTransitionEnd.bind(this)
-    this._setup = this._setup.bind(this)
+    this._validate = this._validate.bind(this)
     this._teardown = this._teardown.bind(this)
 
     // all accordions
@@ -46,7 +46,7 @@ export default class Collapsible {
 
   // private
 
-  _setup(instance) {
+  _validate(instance) {
     const { trigger, id } = this._getCollapsibleData(instance)
 
     if (!id) {

--- a/src/js/collapsible/collapsible.js
+++ b/src/js/collapsible/collapsible.js
@@ -5,6 +5,7 @@ import {
   log,
   startComponent,
   stopComponent,
+  throttle,
 } from "../helpers"
 
 import { Selectors, CssProperties, Events, Messages } from "./constants"
@@ -19,7 +20,7 @@ import { Selectors, CssProperties, Events, Messages } from "./constants"
 export default class Collapsible {
   constructor() {
     // events
-    this._handleClick = this._handleClick.bind(this)
+    this._handleClick = throttle(this._handleClick.bind(this), 400)
     this._setup = this._setup.bind(this)
     this._teardown = this._teardown.bind(this)
 

--- a/src/js/collapsible/collapsible.js
+++ b/src/js/collapsible/collapsible.js
@@ -66,10 +66,10 @@ export default class Collapsible {
       return false
     }
 
-    const collapsibleContentId = `#${id}`
-    const collapsibleContent = dom.find(collapsibleContentId, instance)
+    const contentId = `#${id}`
+    const content = dom.find(contentId, instance)
 
-    if (!collapsibleContent) {
+    if (!content) {
       log(Messages.NO_CONTENT_ERROR(id))
       return false
     }
@@ -80,32 +80,24 @@ export default class Collapsible {
     }
 
     dom.setAttr(trigger, Selectors.ARIA_CONTROLS, id)
-    dom.setAttr(collapsibleContent, Selectors.ARIA_LABELLEDBY, trigger.id)
+    dom.setAttr(content, Selectors.ARIA_LABELLEDBY, trigger.id)
 
-    const collapsibleContentFocusableChildren = getFocusableElements(collapsibleContentId)
     const contentShouldExpand = dom.getAttr(instance, Selectors.DATA_VISIBLE)
 
     if (contentShouldExpand === "false") {
       dom.setAttr(trigger, Selectors.ARIA_EXPANDED, "false")
-      dom.setAttr(collapsibleContent, Selectors.ARIA_HIDDEN, "true")
-
-      collapsibleContentFocusableChildren.forEach(element => {
-        dom.setAttr(element, Selectors.TABINDEX, "-1")
-      })
+      dom.setAttr(content, Selectors.ARIA_HIDDEN, "true")
     } else {
       dom.setAttr(instance, Selectors.DATA_VISIBLE, "true")
-      dom.setStyle(
-        collapsibleContent,
-        CssProperties.MAX_HEIGHT,
-        this._getFontSizeEm(collapsibleContent.scrollHeight)
-      )
+      dom.setStyle(content, CssProperties.HEIGHT, this._getFontSizeEm(content.scrollHeight))
       dom.setAttr(trigger, Selectors.ARIA_EXPANDED, "true")
-      dom.setAttr(collapsibleContent, Selectors.ARIA_HIDDEN, "false")
-
-      collapsibleContentFocusableChildren.forEach(element => {
-        dom.setAttr(element, Selectors.TABINDEX, "0")
-      })
+      dom.setAttr(content, Selectors.ARIA_HIDDEN, "false")
     }
+
+    requestAnimationFrame(() => {
+      dom.addClass(trigger, "collapsible-trigger-ready")
+      dom.addClass(content, "collapsible-content-ready")
+    })
 
     trigger.addEventListener(Events.CLICK, this._handleClick)
 
@@ -143,12 +135,12 @@ export default class Collapsible {
       dom.setAttr(element, Selectors.TABINDEX, value)
     })
 
-    if (dom.getStyle(this._activeContent, CssProperties.MAX_HEIGHT)) {
-      dom.setStyle(this._activeContent, CssProperties.MAX_HEIGHT, null)
+    if (dom.getStyle(this._activeContent, CssProperties.HEIGHT)) {
+      dom.setStyle(this._activeContent, CssProperties.HEIGHT, null)
     } else {
       dom.setStyle(
         this._activeContent,
-        CssProperties.MAX_HEIGHT,
+        CssProperties.HEIGHT,
         this._getFontSizeEm(this._activeContent.scrollHeight)
       )
     }

--- a/src/js/collapsible/constants.js
+++ b/src/js/collapsible/constants.js
@@ -14,7 +14,8 @@ export const Selectors = {
 }
 
 export const CssProperties = {
-  MAX_HEIGHT: "maxHeight",
+  HEIGHT: "height",
+  TRANSITION_DURATION: "transition-duration",
 }
 
 export const Events = {

--- a/src/js/collapsible/constants.js
+++ b/src/js/collapsible/constants.js
@@ -17,7 +17,6 @@ export const Selectors = {
 
 export const CssProperties = {
   HEIGHT: "height",
-  TRANSITION: "transition",
   VISIBILITY: "visibility",
 }
 
@@ -25,7 +24,6 @@ export const CssValues = {
   AUTO: "auto",
   HIDDEN: "hidden",
   VISIBLE: "visible",
-  ZERO_PX: "0px",
 }
 
 export const Events = {

--- a/src/js/collapsible/constants.js
+++ b/src/js/collapsible/constants.js
@@ -1,8 +1,6 @@
 export const Selectors = {
   // unique
   DATA_COLLAPSIBLE: "data-collapsible",
-  TRIGGER_READY_CLASS: "collapsible-trigger-ready",
-  CONTENT_READY_CLASS: "collapsible-content-ready",
   // common
   DATA_VISIBLE: "data-visible",
   DATA_TARGET: "data-target",
@@ -13,6 +11,9 @@ export const Selectors = {
   ARIA_HIDDEN: "aria-hidden",
   ARIA_LABELLEDBY: "aria-labelledby",
   TABINDEX: "tabindex",
+  // classes
+  TRIGGER_READY_CLASS: "collapsible-trigger-ready",
+  CONTENT_READY_CLASS: "collapsible-content-ready",
 }
 
 export const CssProperties = {

--- a/src/js/collapsible/constants.js
+++ b/src/js/collapsible/constants.js
@@ -1,6 +1,8 @@
 export const Selectors = {
   // unique
   DATA_COLLAPSIBLE: "data-collapsible",
+  TRIGGER_READY_CLASS: "collapsible-trigger-ready",
+  CONTENT_READY_CLASS: "collapsible-content-ready",
   // common
   DATA_VISIBLE: "data-visible",
   DATA_TARGET: "data-target",
@@ -15,11 +17,20 @@ export const Selectors = {
 
 export const CssProperties = {
   HEIGHT: "height",
-  TRANSITION_DURATION: "transition-duration",
+  TRANSITION: "transition",
+  VISIBILITY: "visibility",
+}
+
+export const CssValues = {
+  AUTO: "auto",
+  HIDDEN: "hidden",
+  VISIBLE: "visible",
+  ZERO_PX: "0px",
 }
 
 export const Events = {
   CLICK: "click",
+  TRANSITIONEND: "transitionend",
 }
 
 export const Messages = {

--- a/src/js/dropdown/dropdown.js
+++ b/src/js/dropdown/dropdown.js
@@ -24,7 +24,7 @@ export default class Dropdown {
     this._handleClose = this._handleClose.bind(this)
     this._handleEscapeKeyPress = this._handleEscapeKeyPress.bind(this)
     this._handleOffMenuClick = this._handleOffMenuClick.bind(this)
-    this._setup = this._setup.bind(this)
+    this._validate = this._validate.bind(this)
     this._teardown = this._teardown.bind(this)
 
     // all dropdowns
@@ -67,7 +67,7 @@ export default class Dropdown {
 
   // private
 
-  _setup(instance) {
+  _validate(instance) {
     const dropdownId = instance.getAttribute(Selectors.DATA_DROPDOWN)
 
     if (!dropdownId) {

--- a/src/js/helpers/__tests__/utils.spec.js
+++ b/src/js/helpers/__tests__/utils.spec.js
@@ -1,11 +1,5 @@
 import { find, renderDOM, simulateKeyboardEvent } from "../test"
-import {
-  dom,
-  getFocusableElements,
-  createFocusTrap,
-  focusOnce,
-  getPageBaseFontSize,
-} from "../utils"
+import { dom, getFocusableElements, createFocusTrap, focusOnce } from "../utils"
 
 const testDOM = `<div data-tester="true" tabindex="-1" data-removable class="wrapper">
     <p>Hello world! <a tabindex="-1" class="first-focusable" href="#">this link is focusable</a></p>
@@ -371,16 +365,6 @@ describe("getFocusableElements(container)", () => {
   })
 
   it("returns custom list of elements if matchers given", () => {})
-})
-
-describe("getPageBaseFontSize", () => {
-  it("returns body font size as number literal", () => {
-    // Given
-    renderDOM(testDOM)
-    find("body").style.fontSize = "16px"
-    // Then
-    expect(getPageBaseFontSize()).toBe(16)
-  })
 })
 
 describe("focusOnce(element)", () => {

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -20,16 +20,14 @@ const Events = {
 
 const Messages = {
   NO_SELECTOR_STRING_OR_CHILDREN_ERROR:
-    "createFocusTrap must be given one or both of: first parameter (as selector string) and/or options.children (array of elements).",
+    "createFocusTrap must be given one or both of: first parameter (as selector string)" +
+    " and/or options.children (array of elements).",
   OPTION_MATCHERS_DATA_TYPE_ERROR:
     "Invalid data type given to options.matchers for createFocusTrap. Expected: Array.",
   INCORRECT_MATCHER_TYPE_ERROR: type =>
     `Invalid matcher given to options.matchers for createFocusTrap. Expected: String. Recieved: ${type}.`,
   NO_MATCHER_LENGTH_ERROR:
     "Invalid value given to options.matchers for createFocusTrap; value must be an array with at least one selector string",
-  NO_PARENT_FOUND_IN_SCOPE: id => `Element couldn't be found with selector string: '${id}'`,
-  DUPLICATE_SCOPE_ERROR: id =>
-    `You tried to start an Undernet component with scope '${id}', but that scope is already active.\n\nYou must call COMPONENT_NAME.stop(scopeSelector) first, then.`,
 }
 
 /**

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -34,7 +34,6 @@ const Messages = {
 
 /**
  * Log a console message.
- *
  * @param {String} message
  * @param {String} type
  */
@@ -44,6 +43,27 @@ export const log = (message, type = "error") => console[type](message)
  * Check if window exists. If it doesn't, we're probably in a non-test node environment.
  */
 export const isBrowserEnv = typeof window !== "undefined"
+
+/**
+ * Simple throttle utility.
+ * @param {Function} fn - function to throttle
+ * @param {number} limit - in milliseconds
+ */
+export function throttle(fn, limit) {
+  let timeout = null
+
+  function clear() {
+    clearTimeout(timeout)
+    timeout = null
+  }
+
+  return function() {
+    if (timeout) return
+
+    fn.apply(this, arguments)
+    timeout = setTimeout(clear, limit)
+  }
+}
 
 /**
  * Simple DOM manipulator methods. These aren't chainable.

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -329,7 +329,7 @@ export const createFocusRing = () => {
 
 /**
  * Focus a single element one time and teardown when unfocused.
- * @param {Object} element
+ * @param {HTMLElement} element
  */
 export const focusOnce = element => {
   const handleBlur = ({ target }) => {
@@ -372,7 +372,7 @@ export const startComponent = (metadata = {}) => {
     const instance = dom.find(`[${attribute}='${id}']`)
     if (!instance) return
 
-    const validComponent = [instance].filter(thisArg._setup)[0]
+    const validComponent = [instance].filter(thisArg._validate)[0]
     if (!validComponent) return
 
     thisArg._components.push(validComponent)
@@ -380,7 +380,7 @@ export const startComponent = (metadata = {}) => {
     const instances = dom.findAll(`[${attribute}]`)
     if (!instances.length) return
 
-    const validComponents = instances.filter(thisArg._setup)
+    const validComponents = instances.filter(thisArg._validate)
     thisArg._components = thisArg._components.concat(validComponents)
   } else {
     // attempted to .start() when .stop() wasn't run,

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -45,23 +45,23 @@ export const log = (message, type = "error") => console[type](message)
 export const isBrowserEnv = typeof window !== "undefined"
 
 /**
- * Simple throttle utility.
- * @param {Function} fn - function to throttle
- * @param {number} limit - in milliseconds
+ * Simple throttle utility. It is leading but not trailing.
+ * @param {*} callback - function to throttle
+ * @param {number} limit - time to throttle by in milliseconds
  */
-export function throttle(fn, limit) {
-  let timeout = null
+export function throttle(callback, limit) {
+  let timeout = false
 
   function clear() {
-    clearTimeout(timeout)
-    timeout = null
+    timeout = false
   }
 
   return function() {
     if (timeout) return
 
-    fn.apply(this, arguments)
-    timeout = setTimeout(clear, limit)
+    callback.apply(this, arguments)
+    timeout = true
+    setTimeout(clear, limit)
   }
 }
 

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -330,36 +330,6 @@ export const createFocusRing = () => {
 }
 
 /**
- * Get the computed font-size of the page body as a number.
- *
- * ```js
- * const size = getPageBaseFontSize()
- * element.style.lineHeight = `${size * 2}px`
- * ```
- *
- * @returns {Number}
- */
-export const getPageBaseFontSize = () => {
-  if (!isBrowserEnv) return
-
-  const BODY_TAG = "body"
-  const FONT_SIZE_PROPERTY = "font-size"
-  const PX_SUBSTRING = "px"
-  const FONT_SIZE_VALUE_FALLBACK = 16
-
-  const body = dom.find(BODY_TAG)
-  const computedFontSize = window.getComputedStyle(body).getPropertyValue(FONT_SIZE_PROPERTY)
-  let bodySize = FONT_SIZE_VALUE_FALLBACK
-
-  if (computedFontSize) {
-    const indexOfPx = computedFontSize.indexOf(PX_SUBSTRING)
-    bodySize = parseFloat(computedFontSize.slice(0, indexOfPx))
-  }
-
-  return bodySize
-}
-
-/**
  * Focus a single element one time and teardown when unfocused.
  * @param {Object} element
  */

--- a/src/js/modal/__tests__/__snapshots__/modal.spec.js.snap
+++ b/src/js/modal/__tests__/__snapshots__/modal.spec.js.snap
@@ -17,7 +17,7 @@ exports[`Modal #handleClick opens modal 1`] = `
   
   <div
     aria-hidden="false"
-    classname="modal-overlay"
+    class="modal-overlay is-visible"
     data-modal="modal-id"
     data-visible="true"
   >
@@ -26,7 +26,7 @@ exports[`Modal #handleClick opens modal 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
       tabindex="-1"
@@ -37,7 +37,7 @@ exports[`Modal #handleClick opens modal 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -81,7 +81,7 @@ exports[`Modal #handleClick opens modal 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
           tabindex="0"
@@ -93,7 +93,7 @@ exports[`Modal #handleClick opens modal 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
           tabindex="0"
         >
@@ -133,7 +133,7 @@ exports[`Modal #handleClose closes modal 1`] = `
   
   <div
     aria-hidden="true"
-    classname="modal-overlay"
+    class="modal-overlay"
     data-modal="modal-id"
     data-visible="false"
     style="padding-left: 1024px;"
@@ -143,7 +143,7 @@ exports[`Modal #handleClose closes modal 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
     >
@@ -153,7 +153,7 @@ exports[`Modal #handleClose closes modal 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -165,7 +165,7 @@ exports[`Modal #handleClose closes modal 1`] = `
         <a
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           
@@ -197,10 +197,10 @@ exports[`Modal #handleClose closes modal 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           Cancel
@@ -209,9 +209,9 @@ exports[`Modal #handleClose closes modal 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           OK
@@ -249,7 +249,7 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
   
   <div
     aria-hidden="true"
-    classname="modal-overlay"
+    class="modal-overlay"
     data-modal="modal-id"
     data-visible="false"
     style="padding-left: 1024px;"
@@ -259,7 +259,7 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
     >
@@ -269,7 +269,7 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -281,7 +281,7 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
         <a
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           
@@ -313,10 +313,10 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           Cancel
@@ -325,9 +325,9 @@ exports[`Modal #handleEscapeKeyPress closes modal 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           OK
@@ -365,7 +365,7 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
   
   <div
     aria-hidden="true"
-    classname="modal-overlay"
+    class="modal-overlay"
     data-modal="modal-id"
     data-visible="false"
     style="padding-left: 1024px;"
@@ -375,7 +375,7 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
     >
@@ -385,7 +385,7 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -397,7 +397,7 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
         <a
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           
@@ -429,10 +429,10 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           Cancel
@@ -441,9 +441,9 @@ exports[`Modal #handleOverlayClick closes modal 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
-          tabindex="-1"
+          tabindex="0"
         >
           
           OK
@@ -477,7 +477,7 @@ exports[`Modal API start sets attributes 1`] = `
   
   <div
     aria-hidden="true"
-    classname="modal-overlay"
+    class="modal-overlay"
     data-modal="modal-id"
     data-visible="false"
   >
@@ -486,7 +486,7 @@ exports[`Modal API start sets attributes 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
     >
@@ -496,7 +496,7 @@ exports[`Modal API start sets attributes 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -508,7 +508,6 @@ exports[`Modal API start sets attributes 1`] = `
         <a
           data-close=""
           href="#"
-          tabindex="-1"
         >
           
           
@@ -540,10 +539,9 @@ exports[`Modal API start sets attributes 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
-          tabindex="-1"
         >
           
           Cancel
@@ -552,9 +550,8 @@ exports[`Modal API start sets attributes 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
-          tabindex="-1"
         >
           
           OK
@@ -588,7 +585,7 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
   
   <div
     aria-hidden="true"
-    classname="modal-overlay"
+    class="modal-overlay"
     data-modal="modal-id"
     data-visible="false"
   >
@@ -597,7 +594,7 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
     <div
       aria-labelledby="header-id"
       aria-modal="true"
-      classname="modal-dialog"
+      class="modal-dialog"
       data-parent="modal-id"
       role="dialog"
     >
@@ -607,7 +604,7 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
         
         
         <h2
-          classname="h6 has-no-m-block-start"
+          class="h6 has-no-m-block-start"
           id="header-id"
         >
           
@@ -619,7 +616,6 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
         <a
           data-close=""
           href="#"
-          tabindex="-1"
         >
           
           
@@ -651,10 +647,9 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
         
         
         <a
-          classname="button"
+          class="button"
           data-close=""
           href="#"
-          tabindex="-1"
         >
           
           Cancel
@@ -663,9 +658,8 @@ exports[`Modal API stop + #handleClick does not open modal 1`] = `
         
         
         <a
-          classname="primary button"
+          class="primary button"
           href="#"
-          tabindex="-1"
         >
           
           OK

--- a/src/js/modal/constants.js
+++ b/src/js/modal/constants.js
@@ -40,6 +40,7 @@ export const Events = {
 export const Messages = {
   NO_TRIGGER_ERROR: id => `Could not find modal trigger with id ${id}.`,
   NO_ID_ERROR:
-    "Could not detect an id on your [data-modal] element. Please add a value matching the modal trigger's [data-parent] attribute.",
+    "Could not detect an id on your [data-modal] element. " +
+    "Please add a value matching the modal trigger's [data-parent] attribute.",
   NO_MODAL_DIALOG_ERROR: id => `Could not find element with attribute [data-parent='${id}'].`,
 }

--- a/src/js/modal/constants.js
+++ b/src/js/modal/constants.js
@@ -16,7 +16,8 @@ export const Selectors = {
   ROLE: "role",
   TABINDEX: "tabindex",
   // classes
-  NO_SCROLL: "no-scroll",
+  NO_SCROLL_CLASS: "no-scroll",
+  IS_VISIBLE_CLASS: "is-visible",
 }
 
 export const CssProperties = {
@@ -35,6 +36,7 @@ export const Events = {
   CLICK: "click",
   RESIZE: "resize",
   BLUR: "blur",
+  TRANSITIONEND: "transitionend",
 }
 
 export const Messages = {

--- a/src/js/modal/modal.js
+++ b/src/js/modal/modal.js
@@ -35,7 +35,7 @@ export default class Modal {
     this._activeModal = null
     this._activeModalContent = null
     this._activeModalId = ""
-    this._activeModalSelector = ""
+    this._activeModalContentSelector = ""
     this._activeModalCloseTriggers = []
     this._originalPagePadding = ""
     this._scrollbarOffset = null
@@ -71,10 +71,6 @@ export default class Modal {
     const modalAttr = `[${Selectors.DATA_MODAL}='${modalId}']`
     const modal = dom.find(modalAttr)
 
-    getFocusableElements(modalAttr).forEach(element =>
-      dom.setAttr(element, Selectors.TABINDEX, "-1")
-    )
-
     const modalContent = dom.find(`[${Selectors.DATA_PARENT}='${modalId}']`, instance)
 
     if (!modalContent) {
@@ -84,6 +80,7 @@ export default class Modal {
 
     dom.setAttr(modal, Selectors.ARIA_HIDDEN, "true")
     dom.setAttr(modal, Selectors.DATA_VISIBLE, "false")
+    dom.setAttr(modalContent, Selectors.TABINDEX, "-1")
     dom.setAttr(modalContent, Selectors.ARIA_MODAL, "true")
     dom.setAttr(modalContent, Selectors.ROLE, COMPONENT_ROLE)
 
@@ -116,13 +113,12 @@ export default class Modal {
     this._setScrollbarOffset()
     this._setScrollStop()
 
-    this._focusTrap = createFocusTrap(this._activeModalSelector)
+    this._focusTrap = createFocusTrap(this._activeModalContentSelector)
     this._focusTrap.start()
 
     this._toggleVisibility(true)
-    this._changeTabindexOnChildren("0")
+    this._setFocusableChildren()
     this._setCloseTriggers()
-    this._focusModalContent()
 
     // Focusing the modal dialog causes a focus change if the container is larger than the window height
     this._activeModal.scrollTop = 0
@@ -143,11 +139,9 @@ export default class Modal {
 
     document.removeEventListener(Events.KEYDOWN, this._handleEscapeKeyPress)
     document.removeEventListener(Events.CLICK, this._handleOverlayClick)
-    this._changeTabindexOnChildren("-1")
 
     this._activeModalCloseTriggers.forEach(trigger => {
       trigger.removeEventListener(Events.CLICK, this._handleClose)
-      dom.setAttr(trigger, Selectors.TABINDEX, "-1")
     })
 
     this._focusTrap.stop()
@@ -159,23 +153,23 @@ export default class Modal {
     this._activeModalTrigger = null
     this._activeModalContent = null
     this._activeModalId = ""
-    this._activeModalSelector = ""
+    this._activeModalContentSelector = ""
     this._activeModalCloseTriggers = []
     this._originalPagePadding = ""
     this._scrollbarOffset = null
     this._focusTrap = null
   }
 
-  _changeTabindexOnChildren(value) {
-    const elements = getFocusableElements(this._activeModalAttr)
+  _setFocusableChildren() {
+    const elements = getFocusableElements(this._activeModalContentSelector)
     if (!elements.length) return
 
-    elements.forEach(element => dom.setAttr(element, Selectors.TABINDEX, value))
+    elements.forEach(element => dom.setAttr(element, Selectors.TABINDEX, "0"))
   }
 
   _setCloseTriggers() {
     this._activeModalCloseTriggers = dom.findAll(
-      `${this._activeModalSelector} [${Selectors.DATA_CLOSE}]`
+      `${this._activeModalContentSelector} [${Selectors.DATA_CLOSE}]`
     )
   }
 
@@ -189,8 +183,8 @@ export default class Modal {
   }
 
   _setActiveModalContent() {
-    this._activeModalSelector = `[${Selectors.DATA_PARENT}='${this._activeModalId}']`
-    this._activeModalContent = dom.find(this._activeModalSelector, this._activeModal)
+    this._activeModalContentSelector = `[${Selectors.DATA_PARENT}='${this._activeModalId}']`
+    this._activeModalContent = dom.find(this._activeModalContentSelector, this._activeModal)
   }
 
   _toggleVisibility(isVisible) {
@@ -213,10 +207,6 @@ export default class Modal {
     this._activeModalCloseTriggers.forEach(trigger => {
       trigger.addEventListener(Events.CLICK, this._handleClose)
     })
-  }
-
-  _focusModalContent() {
-    focusOnce(this._activeModalContent)
   }
 
   _getScrollbarOffset() {

--- a/src/js/tooltip/tooltip.js
+++ b/src/js/tooltip/tooltip.js
@@ -13,7 +13,7 @@ export default class Tooltip {
     this._handleEvent = this._handleEvent.bind(this)
     this._handleClose = this._handleClose.bind(this)
     this._handleEscapeKeyPress = this._handleEscapeKeyPress.bind(this)
-    this._setup = this._setup.bind(this)
+    this._validate = this._validate.bind(this)
     this._teardown = this._teardown.bind(this)
 
     // all tooltips
@@ -42,7 +42,7 @@ export default class Tooltip {
 
   // private
 
-  _setup(instance) {
+  _validate(instance) {
     const instanceId = dom.getAttr(instance, Selectors.DATA_TOOLTIP)
 
     if (!instanceId) {

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -158,7 +158,7 @@ $global-arrow-size: 7px !default;
 
 $global-line-height: 1.3 !default;
 $global-ease: cubic-bezier(0.12, 0.72, 0.58, 1.03) !default;
-$global-transition: $global-ease 0.1s !default;
+$global-transition: $global-ease 100ms !default;
 
 $global-border-radius: 4px !default;
 $global-border-width: 2px !default;
@@ -764,7 +764,7 @@ $form-fieldset-legend-border-radius: $global-border-radius !default;
 // ----------
 
 $modal-overlay-color: rgba(0, 0, 0, 0.5) !default;
-$modal-transition-duration: 0.3s !default;
+$modal-transition-duration: 300ms !default;
 $modal-transition-ease: $global-ease !default;
 
 $modal-dialog-bg-color: $color-white !default;
@@ -818,9 +818,7 @@ $collapsible-indicator-closed: "" !default;
 $collapsible-indicator-transform: rotate(180deg) !default;
 $collapsible-indicator-weight: bold !default;
 
-// Transition duration and easing function during visible state change.
-
-$collapsible-transition-duration: 400ms !default;
+$collapsible-transition-duration: 300ms !default;
 $collapsible-transition-ease: $global-ease !default;
 
 $collapsible-trigger-color: $color-primary !default;

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -820,7 +820,7 @@ $collapsible-indicator-weight: bold !default;
 
 // Transition duration and easing function during visible state change.
 
-$collapsible-transition-duration: 0.5s !default;
+$collapsible-transition-duration: 400ms !default;
 $collapsible-transition-ease: $global-ease !default;
 
 $collapsible-trigger-color: $color-primary !default;

--- a/src/scss/components/_collapsible.scss
+++ b/src/scss/components/_collapsible.scss
@@ -2,26 +2,6 @@
   @return $collapsible-indicator-open != "" and $collapsible-indicator-closed != "";
 }
 
-.collapsible {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    padding: 0;
-    margin: 0;
-  }
-
-  &[data-visible="false"] .collapsible-trigger::after {
-    @if custom-indicators-configured() {
-      content: $collapsible-indicator-closed;
-    } @else if $collapsible-indicator {
-      transform: $collapsible-indicator-transform;
-    }
-  }
-}
-
 .collapsible-trigger {
   display: flex;
   flex-flow: row nowrap;
@@ -54,6 +34,26 @@
 
   &.collapsible-trigger-ready::after {
     transition: transform $collapsible-transition-duration $collapsible-transition-ease;
+  }
+}
+
+.collapsible {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    padding: 0;
+    margin: 0;
+  }
+
+  &[data-visible="false"] .collapsible-trigger::after {
+    @if custom-indicators-configured() {
+      content: $collapsible-indicator-closed;
+    } @else if $collapsible-indicator {
+      transform: $collapsible-indicator-transform;
+    }
   }
 }
 

--- a/src/scss/components/_collapsible.scss
+++ b/src/scss/components/_collapsible.scss
@@ -14,10 +14,10 @@
   }
 
   &[data-visible="false"] .collapsible-trigger::after {
-    transform: $collapsible-indicator-transform;
-
     @if custom-indicators-configured() {
       content: $collapsible-indicator-closed;
+    } @else if $collapsible-indicator {
+      transform: $collapsible-indicator-transform;
     }
   }
 }
@@ -44,7 +44,6 @@
   &::after {
     font-size: 12px;
     font-weight: $collapsible-indicator-weight;
-    transition: $collapsible-transition-duration $collapsible-transition-ease;
 
     @if custom-indicators-configured() {
       content: $collapsible-indicator-open;
@@ -52,12 +51,21 @@
       content: $collapsible-indicator;
     }
   }
+
+  &.collapsible-trigger-ready::after {
+    transition: transform $collapsible-transition-duration $collapsible-transition-ease;
+  }
 }
 
 .collapsible-content {
   overflow: hidden;
   padding: 0;
   margin: 0;
-  max-height: 0;
-  transition: max-height $collapsible-transition-duration $collapsible-transition-ease;
+  height: 0;
+
+  &.collapsible-content-ready {
+    transition-property: visibility, height;
+    transition-duration: $collapsible-transition-duration;
+    transition-timing-function: $collapsible-transition-ease;
+  }
 }

--- a/src/scss/components/_collapsible.scss
+++ b/src/scss/components/_collapsible.scss
@@ -59,6 +59,7 @@
 
 .collapsible-content {
   overflow: hidden;
+  visibility: hidden;
   padding: 0;
   margin: 0;
   height: 0;

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -1,18 +1,3 @@
-.dropdown {
-  position: relative;
-  display: inline-block;
-
-  > [data-target] {
-    display: inline-flex;
-    align-items: center;
-  }
-
-  &[data-visible="true"] > .dropdown-menu {
-    opacity: 1;
-    pointer-events: auto;
-  }
-}
-
 .dropdown-menu {
   @include create-flow-property("padding-left", 0);
   position: absolute;
@@ -158,5 +143,20 @@
       padding: $dropdown-header-padding;
       color: $dropdown-header-color;
     }
+  }
+}
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+
+  > [data-target] {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  &[data-visible="true"] > .dropdown-menu {
+    opacity: 1;
+    pointer-events: auto;
   }
 }

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -22,8 +22,11 @@
 
   &[data-visible="true"] {
     opacity: 1;
-    visibility: visible;
     pointer-events: auto;
+  }
+
+  &.is-visible {
+    visibility: visible;
   }
 }
 
@@ -58,7 +61,7 @@
   h4,
   h5,
   h6 {
-    @include create-truncation();
+    @include create-truncation;
   }
 
   @if str-index($modal-header-border-position, "end") {

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -12,11 +12,17 @@
   bottom: 0;
   left: 0;
   right: 0;
-  transition: opacity $modal-transition-duration $modal-transition-ease;
+
+  // default hidden
+  transition-property: opacity, visibility;
+  transition-duration: $modal-transition-duration;
+  transition-timing-function: $modal-transition-ease;
   pointer-events: none;
+  visibility: hidden;
 
   &[data-visible="true"] {
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
   }
 }


### PR DESCRIPTION
Instead of setting focusable elements to tabindex of `-1`, we'll throttle the collapse click and add `visibility: hidden` when closed, and `visibility: visible` when open, and remove the max-height when expanded.

Modal will also receive the `visibility` property update in the same closed/open state.